### PR TITLE
Start at the top: write-all permissions on composer diff workflow

### DIFF
--- a/.github/workflows/composer-diff.yaml
+++ b/.github/workflows/composer-diff.yaml
@@ -5,10 +5,7 @@ on:
       - opened
       - synchronize
       - reopened
-permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+permissions: write-all
 jobs:
   comment-composer-lock-diff:
     name: Comment composer.lock diff


### PR DESCRIPTION
Ok this is going to be a very long string of commits, but seems that the only way to figure out which permissions are required to comment is by testing them one by one