### PR TITLE
feat: add allowMissing flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,12 @@ jobs:
               workingDirectory: generate-comments/
             with:
               workingDirectory: generate-comments/
+          - name: Disallow Missing
+            withDry:
+              dryRun: yes
+              allowMissing: 'no'
+            with:
+              allowMissing: 'no'
     needs:
       - build-docker-image
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Which directory to run the composer diffing in.
 * *Type*: `string`
 * *Example*: `path/to/directory/`
 
+### allowMissing
+
+Whether to treat missing `composer.lock` files as empty. Set this to `no` to disable this behavior.
+
+* *Required*: `No`
+* *Default*: `yes`
+* *Type*: `string`
+* *Example*: `no`
+
 ## Output
 
 This action has two outputs: the `production` and `development` outputs respective tables for each set of dependencies.

--- a/action.yaml
+++ b/action.yaml
@@ -12,6 +12,10 @@ inputs:
     description: Directory to execute the diff generator in
     required: false
     default: ''
+  allowMissing:
+    description: Treat missing composer.lock files as empty, set to "no" to disable, on by default.
+    required: false
+    default: 'yes'
 outputs:
   production:
     description: Changed production dependencies table
@@ -98,3 +102,4 @@ runs:
       with:
         dryRun: ${{ inputs.dryRun }}
         workingDirectory: ${{ steps.workingDirectory.outputs.result }}
+        allowMissing: ${{ inputs.allowMissing }}

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "php": "^8.3",
     "composer/composer": "^2.7.7",
     "guzzlehttp/guzzle": "^7.8.0",
-    "ion-bazan/composer-diff": "^1.9",
+    "ion-bazan/composer-diff": "^2.2",
     "symfony/console": "^7.0.0"
   },
   "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b6251ce102d0d50cd00499bf966b0dc",
+    "content-hash": "810aa3202d3c86a9c79bc00f151eb8ef",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -952,27 +952,27 @@
         },
         {
             "name": "ion-bazan/composer-diff",
-            "version": "v1.9.0",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/IonBazan/composer-diff.git",
-                "reference": "d7f3cd5333c760d5bdfe0178571c99f52979bb9f"
+                "reference": "674613447e20bc0891b2b77b441424f567546334"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/IonBazan/composer-diff/zipball/d7f3cd5333c760d5bdfe0178571c99f52979bb9f",
-                "reference": "d7f3cd5333c760d5bdfe0178571c99f52979bb9f",
+                "url": "https://api.github.com/repos/IonBazan/composer-diff/zipball/674613447e20bc0891b2b77b441424f567546334",
+                "reference": "674613447e20bc0891b2b77b441424f567546334",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1 || ^2.0",
+                "composer-plugin-api": "^2.0",
                 "ext-json": "*",
-                "php": ">=5.3.2"
+                "php": ">=7.2"
             },
             "require-dev": {
-                "composer/composer": "^1.1 || ^2.0",
-                "symfony/console": "^2.3 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
-                "symfony/phpunit-bridge": "^4.2 || ^5.0 || ^6.0 || ^7.0"
+                "composer/composer": "^2.0",
+                "symfony/console": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/phpunit-bridge": "^5.4.33 || ^6.0 || ^7.0 || ^8.0"
             },
             "suggest": {
                 "composer/composer": "To use the binary without composer runtime",
@@ -1013,7 +1013,7 @@
             ],
             "support": {
                 "issues": "https://github.com/IonBazan/composer-diff/issues",
-                "source": "https://github.com/IonBazan/composer-diff/tree/v1.9.0"
+                "source": "https://github.com/IonBazan/composer-diff/tree/v2.2.0"
             },
             "funding": [
                 {
@@ -1021,7 +1021,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-26T11:05:06+00:00"
+            "time": "2026-07-17T16:15:31+00:00"
         },
         {
             "name": "justinrainbow/json-schema",

--- a/generate-comments/composer.json
+++ b/generate-comments/composer.json
@@ -5,7 +5,7 @@
     "php": "^8.3",
     "composer/composer": "^2.7.7",
     "guzzlehttp/guzzle": "^7.8.0",
-    "ion-bazan/composer-diff": "^1.9",
+    "ion-bazan/composer-diff": "^2.2",
     "symfony/console": "^7.0.0"
   },
   "config": {

--- a/generate-comments/composer.lock
+++ b/generate-comments/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b6251ce102d0d50cd00499bf966b0dc",
+    "content-hash": "810aa3202d3c86a9c79bc00f151eb8ef",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -952,27 +952,27 @@
         },
         {
             "name": "ion-bazan/composer-diff",
-            "version": "v1.9.0",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/IonBazan/composer-diff.git",
-                "reference": "d7f3cd5333c760d5bdfe0178571c99f52979bb9f"
+                "reference": "674613447e20bc0891b2b77b441424f567546334"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/IonBazan/composer-diff/zipball/d7f3cd5333c760d5bdfe0178571c99f52979bb9f",
-                "reference": "d7f3cd5333c760d5bdfe0178571c99f52979bb9f",
+                "url": "https://api.github.com/repos/IonBazan/composer-diff/zipball/674613447e20bc0891b2b77b441424f567546334",
+                "reference": "674613447e20bc0891b2b77b441424f567546334",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1 || ^2.0",
+                "composer-plugin-api": "^2.0",
                 "ext-json": "*",
-                "php": ">=5.3.2"
+                "php": ">=7.2"
             },
             "require-dev": {
-                "composer/composer": "^1.1 || ^2.0",
-                "symfony/console": "^2.3 || ^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
-                "symfony/phpunit-bridge": "^4.2 || ^5.0 || ^6.0 || ^7.0"
+                "composer/composer": "^2.0",
+                "symfony/console": "^5.4 || ^6.0 || ^7.0 || ^8.0",
+                "symfony/phpunit-bridge": "^5.4.33 || ^6.0 || ^7.0 || ^8.0"
             },
             "suggest": {
                 "composer/composer": "To use the binary without composer runtime",
@@ -1013,7 +1013,7 @@
             ],
             "support": {
                 "issues": "https://github.com/IonBazan/composer-diff/issues",
-                "source": "https://github.com/IonBazan/composer-diff/tree/v1.9.0"
+                "source": "https://github.com/IonBazan/composer-diff/tree/v2.2.0"
             },
             "funding": [
                 {
@@ -1021,7 +1021,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-26T11:05:06+00:00"
+            "time": "2026-07-17T16:15:31+00:00"
         },
         {
             "name": "justinrainbow/json-schema",

--- a/generate-comments/entrypoint.sh
+++ b/generate-comments/entrypoint.sh
@@ -7,9 +7,14 @@ echo "Working Directory:"
 workingDirectory=$(echo "${INPUT_WORKINGDIRECTORY}")
 echo "${workingDirectory}"
 
-/workdir/vendor/bin/composer-diff ".wyrihaximus-composer.lock-diff/checkout/base-ref/${workingDirectory}composer.lock" ".wyrihaximus-composer.lock-diff/checkout/sha-sha/${workingDirectory}composer.lock" --allow-missing --with-links --with-platform --no-dev -vvv > /workdir/production.md
+set -- --with-links --with-platform
+if [ "$INPUT_ALLOWMISSING" = "yes" ]; then
+  set -- --allow-missing "$@"
+fi
+
+/workdir/vendor/bin/composer-diff ".wyrihaximus-composer.lock-diff/checkout/base-ref/${workingDirectory}composer.lock" ".wyrihaximus-composer.lock-diff/checkout/sha-sha/${workingDirectory}composer.lock" "$@" --no-dev -vvv > /workdir/production.md
 production=$(cat /workdir/production.md)
-/workdir/vendor/bin/composer-diff ".wyrihaximus-composer.lock-diff/checkout/base-ref/${workingDirectory}composer.lock" ".wyrihaximus-composer.lock-diff/checkout/sha-sha/${workingDirectory}composer.lock" --allow-missing --with-links --with-platform --no-prod -vvv > /workdir/development.md
+/workdir/vendor/bin/composer-diff ".wyrihaximus-composer.lock-diff/checkout/base-ref/${workingDirectory}composer.lock" ".wyrihaximus-composer.lock-diff/checkout/sha-sha/${workingDirectory}composer.lock" "$@" --no-prod -vvv > /workdir/development.md
 development=$(cat /workdir/development.md)
 
 echo "Raw:"

--- a/generate-comments/entrypoint.sh
+++ b/generate-comments/entrypoint.sh
@@ -7,9 +7,9 @@ echo "Working Directory:"
 workingDirectory=$(echo "${INPUT_WORKINGDIRECTORY}")
 echo "${workingDirectory}"
 
-/workdir/vendor/bin/composer-diff ".wyrihaximus-composer.lock-diff/checkout/base-ref/${workingDirectory}composer.lock" ".wyrihaximus-composer.lock-diff/checkout/sha-sha/${workingDirectory}composer.lock" --with-links --with-platform --no-dev -vvv > /workdir/production.md
+/workdir/vendor/bin/composer-diff ".wyrihaximus-composer.lock-diff/checkout/base-ref/${workingDirectory}composer.lock" ".wyrihaximus-composer.lock-diff/checkout/sha-sha/${workingDirectory}composer.lock" --allow-missing --with-links --with-platform --no-dev -vvv > /workdir/production.md
 production=$(cat /workdir/production.md)
-/workdir/vendor/bin/composer-diff ".wyrihaximus-composer.lock-diff/checkout/base-ref/${workingDirectory}composer.lock" ".wyrihaximus-composer.lock-diff/checkout/sha-sha/${workingDirectory}composer.lock" --with-links --with-platform --no-prod -vvv > /workdir/development.md
+/workdir/vendor/bin/composer-diff ".wyrihaximus-composer.lock-diff/checkout/base-ref/${workingDirectory}composer.lock" ".wyrihaximus-composer.lock-diff/checkout/sha-sha/${workingDirectory}composer.lock" --allow-missing --with-links --with-platform --no-prod -vvv > /workdir/development.md
 development=$(cat /workdir/development.md)
 
 echo "Raw:"


### PR DESCRIPTION
This adds an `allowMissing` input to the action.
It was added to the underlying package in https://github.com/IonBazan/composer-diff/pull/54.

This helps when adding new composer.lock files, which should show the full list of packages as a diff.
Biggest use-case for this is in combination with [composer-bin](https://github.com/bamarni/composer-bin-plugin/), where tools are installed independent from the actual project in separate directories.

